### PR TITLE
Corrected local variance field (sigma) calculation (ref. paper)

### DIFF
--- a/brisque_revised/brisque.cpp
+++ b/brisque_revised/brisque.cpp
@@ -26,13 +26,12 @@ void ComputeBrisqueFeature(IplImage *orig, vector<double>& featurevector)
 
 		//compute sigma
 		IplImage* sigma = cvCreateImage(cvGetSize(imdist_scaled), IPL_DEPTH_64F, 1);
-		cvMul(imdist_scaled, imdist_scaled, sigma);
-		cvSmooth(sigma, sigma, CV_GAUSSIAN, 7, 7, 1.16666 );
-		cvSub(sigma, mu_sq, sigma);
-		cvPow(sigma, sigma, 0.5);
-
-		//compute structdis = (x-mu)/sigma
-		cvAddS(sigma, cvScalar(1.0/255), sigma);
+	    	cvSub(imdist_scaled, mu, sigma); 
+	    	cvPow(sigma, sigma, 2); 
+	    	cvSmooth(sigma, sigma, CV_GAUSSIAN, 7, 7, 1.16666);
+	    	cvPow(sigma, sigma, 0.5);
+	    	
+	    	// add scalar to avoid divide by zero exception
 		IplImage* structdis = cvCreateImage(cvGetSize(imdist_scaled), IPL_DEPTH_64F, 1);
 		cvSub(imdist_scaled, mu, structdis);
 		cvDiv(structdis, sigma, structdis);


### PR DESCRIPTION
#1 
**What changes and why?**
The way MSCN coefficients are calculated, didn't match with the given equations in the paper. The original form to calculate sigma (local variance field) should be:
sigma = sqrt(Gaussian((im - mu) ** 2))

While the used form is:
sigma = sqrt(Gaussian(im * im) - Gaussian(mu * mu))

This produces a slight change in the score, but also matches with the paper now.

**What does the pull request do?**
This pull request corrects the calculation of local variance field.